### PR TITLE
Use a custom commit message when deploying to Gh-pages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ var clean = require('gulp-clean');
 var browserSync = require('browser-sync');
 var spawn = require('child_process').spawn;
 var ghPages = require('gulp-gh-pages');
+var argv = require('yargs').argv;
 
 gulp.task('jekyll-prod', function (gulpCallBack){
    var enviroment = process.env

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -95,8 +95,11 @@ gulp.task('browser-sync', ['jekyll-dev', 'sass-on-build'], function() {
 });
 
 gulp.task('deploy', function() {
+  var message = argv.m || 'Update ' + new Date().toISOString();
   return gulp.src('./_site/**/*')
-    .pipe(ghPages());
+    .pipe(ghPages({
+      message: argv.m
+    }));
 });
 
 gulp.task('watch', function() {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gulp-ruby-sass": "^1.4.0",
     "gulp-uglify": "^1.3.0",
     "jshint-stylish": "^2.0.1",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^3.25.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -24,5 +24,5 @@ Production ready site will be generated in '\_site/' folder. Open and check inde
 When ready push to gh-pages branch with:
 
 ```
-gulp deploy
+gulp deploy --m 'Commit message'
 ```


### PR DESCRIPTION
Currently the gh-pages branch looks like - 'Update - [timestamp]' while not terrible might be easier to use named deploys or versions.