### PR TITLE
:bug: add missing css rule for primary headings

### DIFF
--- a/sass/partials/_shared.scss
+++ b/sass/partials/_shared.scss
@@ -34,6 +34,9 @@
 .section-header--without-description {
   height: 65px;
 }
+.section-header--primary {
+  text-transform: uppercase;
+}
 
 .section-header--modal {
   cursor: pointer;


### PR DESCRIPTION
 I accidentally removed this in the css refactor. Adds the modifier back, used on the tickets section header.