### PR TITLE
:bug: fix - add build task as a hard dependency of deploy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,7 +94,7 @@ gulp.task('browser-sync', ['jekyll-dev', 'sass-on-build'], function() {
     });
 });
 
-gulp.task('deploy', function() {
+gulp.task('deploy', ['build'], function() {
   var message = argv.m || 'Update ' + new Date().toISOString();
   return gulp.src('./_site/**/*')
     .pipe(ghPages({


### PR DESCRIPTION
This ensures the development version can never be deployed by acident. Build should still be ran and QA tested before deployment.