### PR TITLE
Create event that triggers after 30 secs on page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,6 +38,10 @@
       ga('create', 'UA-38376593-4', 'auto');
       ga('send', 'pageview');
 
+      setTimeout(function(){
+        ga('send', 'event', 'Page Interaction')
+      }, 30000)
+
     </script>
 
     <!-- Google Code for Remarketing Tag -->


### PR DESCRIPTION
This will fix #20, the great thing about events is that by triggering them it causes the single page view to not contribute towards the bounce rate see http://davidwalsh.name/analytics-bounce-rate