### PR TITLE
Display name not position as workshop subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@ speaker_order:
     <img class="session__image session__image--workshop" src="/img/{{sketch.image_alt-home}}">
     <div class="session__info session__info--workshop">
       <h2 class="session__title session__title--workshop">{{sketch.title}}</h2>
-      <h3 class="session__name session__name--workshop">{{sketch.position}}</h3>
+      <h3 class="session__name session__name--workshop">{{sketch.name}}</h3>
     </div>
   </a>
 


### PR DESCRIPTION
Quick fix so the subtitle for workshops reflects something more useful. 