### PR TITLE
Fix - Modernizr not being imported

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@
 import $ from 'jquery';
 import fitvids from 'fitvids';
 import svgeezy from 'svgeezy';
+import Modernizr from 'modernizr-mq';
 
 //modules
 import countdown from './modules/countdown';

--- a/js/modules/ui-actions.js
+++ b/js/modules/ui-actions.js
@@ -1,5 +1,3 @@
-//vendor
-import Modernizr from 'modernizr-mq';
 
 //Modules
 import schedule from './schedule';


### PR DESCRIPTION
We were getting this error on inital load onlt that looked like it was okay after refresh - it was not. 
![screen shot 2015-10-20 at 12 54 56](https://cloud.githubusercontent.com/assets/2798285/10606310/eba323de-7729-11e5-901f-e1c20e08da7d.png)

Moving the import into main.js solved the issue. I think this might be because of the path used in package.json to reference the modernizr module.

Modernizr is used to check media queries in JS and keep the user on the index page when clicking on speaker info on mobile sizes. Also creates html5 elements on ie8 down with html5 shiv.