### PR TITLE
Header Beyond logo alignment 

### DIFF
--- a/sass/partials/_header.scss
+++ b/sass/partials/_header.scss
@@ -14,7 +14,7 @@
   width: 230px;
   margin: 0 10px 0 0;
 
-  @include media($tablet) {
+  @include media($mobile) {
     float: none;
     display: block;
     width: 200px;


### PR DESCRIPTION
Spotted what I think is a bug. It looks like somewhere we caused the header logo to centre earlier than it should e.g on tablet size when it should only be on mobile. Screenshots are both just after 800px;

Current Version
<img width="822" alt="screen shot 2015-10-20 at 13 36 40" src="https://cloud.githubusercontent.com/assets/2798285/10607200/cd12c31a-772f-11e5-8262-415fa91f5da7.png">

Updated version (Think is is what it should have been) can you confirm @alicemollon ?

<img width="837" alt="screen shot 2015-10-20 at 13 36 47" src="https://cloud.githubusercontent.com/assets/2798285/10607205/d7588b8e-772f-11e5-9f43-3cb3d9995b88.png">

