### PR TITLE
fix workshop layout to break

### DIFF
--- a/sass/partials/_sessions.scss
+++ b/sass/partials/_sessions.scss
@@ -248,6 +248,7 @@
 }
 .session.session--coming-soon {
   background-color: $beyond-blue;
+  float: left;
   @include media($tablet) {
     display: none;
   }


### PR DESCRIPTION
Had a bit of this type of thing at certain sizes that I never spotted. Caused because the div for coming soon is block and the anchors are inline. 

![screen shot 2015-10-21 at 16 17 42](https://cloud.githubusercontent.com/assets/2798285/10641257/57b65280-7810-11e5-9f0c-54966f0f1f36.png)