### PR TITLE
update data in schedule fixes #78

### DIFF
--- a/_data/workshops.yaml
+++ b/_data/workshops.yaml
@@ -44,7 +44,8 @@
 
 - workshop: true
   soon: schedule__session--coming-soon
-  name: Workshop
+  name:
+  anchor: tbc
   title: Session TBC
   description: >
     <p>Coming Soon</p>


### PR DESCRIPTION
The workshops schedule loop looks for an anchor to match with the data file, looks like this got deleted when adding in github as a workshop. 

Name left blank so you only see the title.
![screen shot 2015-10-21 at 16 34 46](https://cloud.githubusercontent.com/assets/2798285/10641561/ab607e3c-7811-11e5-85b2-71b36beecb99.png)
