### PR TITLE
fix scheduleSpeakerInfo being called when it should not be

### DIFF
--- a/js/modules/schedule.js
+++ b/js/modules/schedule.js
@@ -19,7 +19,7 @@ class Schedule {
     if(hash === '#anchor-js' || hash === '#anchor-sketch' || hash === '#anchor-github'){
       this.toggleSchedule('workshops');
     }
-    if(hash !== '#workshops' && hash !== '#talks'){
+    if(hash !== '#workshops' && hash !== '#talks' && hash !== ''){
         this.scheduleSPeakerInfo(hash);
     }
     console.log(hash);


### PR DESCRIPTION
Might have noticed this error cropping up when navigating to the Schedule page, was not causing any damage but was trying to open the speaker model because of bug below.

![screen shot 2015-10-21 at 16 56 06](https://cloud.githubusercontent.com/assets/2798285/10642332/16bce7a8-7815-11e5-89f9-8ff58b3eaf75.png)

When there is no has this is being called when it is used to show a speaker after navigating from the index page. Also check for empty hash before calling.

This needs to be looked at again because it is serving multiple purposes and confusing. 