### PR TITLE
Fix - Show correct OG info on audio posts

### DIFF
--- a/interviews/_posts/2015-10-20-an-interview-with-alana-wood.md
+++ b/interviews/_posts/2015-10-20-an-interview-with-alana-wood.md
@@ -1,5 +1,6 @@
 ---
 layout: audio-post
+post: true
 title: An Interview With Alana Wood
 date: 2015-10-20 10:00:00
 blog_feature_image: interview-alana-wood-preview.jpg

--- a/interviews/_posts/2015-11-03-an-interview-with-una-kravets.md
+++ b/interviews/_posts/2015-11-03-an-interview-with-una-kravets.md
@@ -1,5 +1,6 @@
 ---
 layout: audio-post
+post: true
 title: An Interview With Una Kravats
 date: 2015-11-04 10:00:00
 blog_feature_image: interview-una-kravets-preview.png

--- a/interviews/_posts/2015-11-06-an-interview-with-maxim-cramer.md
+++ b/interviews/_posts/2015-11-06-an-interview-with-maxim-cramer.md
@@ -1,5 +1,6 @@
 ---
 layout: audio-post
+post: true
 title: An Interview With Maxim Cramer
 date: 2015-11-06 10:00:00
 blog_feature_image: interview-maxim-cramer-preview.png


### PR DESCRIPTION
The OG information is within the default layout so to check the type of page we need to use a custom front matter variable. To be recognised we need the `post: true` as seen below

![screen shot 2015-11-06 at 12 33 44](https://cloud.githubusercontent.com/assets/2798285/10997161/b4a1edd2-8482-11e5-9b0e-039e1a7aba4c.png)