### PR TITLE
content - spelling us - uk

### DIFF
--- a/_data/speakers.yaml
+++ b/_data/speakers.yaml
@@ -70,7 +70,7 @@
   description: >
     <p>Looking at web performance advice can be overwhelming: everything comes with caveats, disclaimers, and sometimes one piece of advice can seem to actively contradict another. </p>
     <p>Phrases like “the DOM is slow” or “always use CSS animations!” make for great headlines, but the truth is often far more nuanced. </p>
-    <p>In this session we'll look at how to think holistically about performance, and how to prioritize optimization work that your users will notice and appreciate.</p>
+    <p>In this session we'll look at how to think holistically about performance, and how to prioritise optimisation work that your users will notice and appreciate.</p>
 
 - speaker: false
   duration: 30


### PR DESCRIPTION
Tiny copy change to fix us spelling of words within speaker desc. 